### PR TITLE
Cleanup: fix api server resp in deploy api

### DIFF
--- a/src/api-server/http/module_manager.go
+++ b/src/api-server/http/module_manager.go
@@ -149,7 +149,7 @@ func (mgr *ModuleManager) deployCode(c *gin.Context) {
 
 	log.Info("create PG table and Grafana dashboard success.")
 
-	c.JSON(http.StatusOK, gin.H{"code": "200", "message": "prepare to deploy ...", "id": uid})
+	c.JSON(http.StatusOK, gin.H{"code": "200", "message": "prepare to deploy module, id: " + uid})
 }
 
 func (mgr *ModuleManager) undeployCode(c *gin.Context) {


### PR DESCRIPTION
As `starship-cli` will receive detail info of modules in `data` field, It would not define `ID` to parse `api-server` body.

https://github.com/tricorder-observability/starship/blob/46bdb37780d6596f43dfc30affc7f4c18c0f9a5e/src/cli/internal/model/response.go#L5