### PR TITLE
Cleanup: add license fix and check ci

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,0 +1,13 @@
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  license-header:
+    name: License header
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check license header
+        uses: apache/skywalking-eyes@bd8d2db65f2fea938b74401ae72b0365733bdfdc

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -3,7 +3,7 @@ header:
     # refs: https://spdx.org/licenses/
     spdx-id: AGPL-3.0-or-later
     content: |
-      Copyright (C) 2023  tricorder-observability
+      Copyright (C) 2023 Tricorder Observability
 
       This program is free software: you can redistribute it and/or modify
       it under the terms of the GNU Affero General Public License as published by

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -37,4 +37,5 @@ header:
     - '**/*.yml'
     - '**/*.tar.gz'
     - 'src/testing/bazel/test'
+    - 'src/utils/tar/testdata/hello.txt'
     - 'src/agent/ebpf/bcc/linux_headers/testdata/config'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,18 @@
+header:
+  license:
+    # refs: https://spdx.org/licenses/
+    spdx-id: AGPL-3.0-or-later
+    copyright-owner: tricorder
+    content: |
+      license content here,test
+
+  # The paths are the path list that will be checked (and fixed)
+  paths:
+    - 'src/**'
+
+  paths-ignore: # <8>
+    - 'src/**/.h'
+    - 'src/**/.c'
+    - 'src/**/.wasm'
+    - 'src/**/.pb.go'
+    - 'src/**/.bazel'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -2,17 +2,39 @@ header:
   license:
     # refs: https://spdx.org/licenses/
     spdx-id: AGPL-3.0-or-later
-    copyright-owner: tricorder
     content: |
-      license content here,test
+      Copyright (C) 2023  tricorder-observability
+
+      This program is free software: you can redistribute it and/or modify
+      it under the terms of the GNU Affero General Public License as published by
+      the Free Software Foundation, either version 3 of the License, or
+      (at your option) any later version.
+
+      This program is distributed in the hope that it will be useful,
+      but WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+      GNU Affero General Public License for more details.
+
+      You should have received a copy of the GNU Affero General Public License
+      along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   # The paths are the path list that will be checked (and fixed)
   paths:
     - 'src/**'
 
-  paths-ignore: # <8>
-    - 'src/**/.h'
-    - 'src/**/.c'
-    - 'src/**/.wasm'
-    - 'src/**/.pb.go'
-    - 'src/**/.bazel'
+  paths-ignore:
+    - '**/*.md'
+    - '**/*.h'
+    - '**/*.wat'
+    - '**/*.c'
+    - '**/LICENSE'
+    - '**/*.conf'
+    - '**/*.wasm'
+    - '**/*.proto'
+    - '**/*.pb.go'
+    - '**/BUILD.bazel'
+    - '**/*.yaml'
+    - '**/*.yml'
+    - '**/*.tar.gz'
+    - 'src/testing/bazel/test'
+    - 'src/agent/ebpf/bcc/linux_headers/testdata/config'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+
+.PHONY: install-tools
+install-tools:
+	go install github.com/apache/skywalking-eyes/cmd/license-eye@latest
+
+.PHONY: addlicense
+addlicense: install-tools
+	license-eye -c .licenserc.yaml header fix
+
+.PHONY: checklicense
+checklicense: install-tools
+	license-eye -c .licenserc.yaml header check

--- a/devops/license/Makefile
+++ b/devops/license/Makefile
@@ -1,3 +1,4 @@
+ToT:=$(shell git rev-parse --show-toplevel)
 
 .PHONY: install-tools
 install-tools:
@@ -5,8 +6,8 @@ install-tools:
 
 .PHONY: addlicense
 addlicense: install-tools
-	license-eye -c .licenserc.yaml header fix
+	cd ${ToT} && license-eye -c .licenserc.yaml header fix
 
 .PHONY: checklicense
 checklicense: install-tools
-	license-eye -c .licenserc.yaml header check
+	cd ${ToT} && license-eye -c .licenserc.yaml header check

--- a/devops/license/README.md
+++ b/devops/license/README.md
@@ -11,7 +11,6 @@ And licnese content follows [AGPL3 license header](https://github.com/licenses/l
 When you create new file in `src/` directory, we need to add and check License header before your push.
 
 ```shell
-cd starship
 make addlicense
 ```
 
@@ -20,7 +19,6 @@ make addlicense
 # How to check license
 
 ```shell
-cd starship
 make checklicense
 ```
 

--- a/devops/license/README.md
+++ b/devops/license/README.md
@@ -1,5 +1,28 @@
 # License
 
-Regarding how to manage licenses.
+Starship use [skywalking-eyes](https://github.com/apache/skywalking-eyes) to 
+check and fix License header.
 
-[AGPL3 license header](https://github.com/licenses/license-templates/blob/master/templates/agpl3-header.txt)
+License header check and fix rule `.licenserc.yaml` defined in the root of starship.
+
+And licnese content follows [AGPL3 license header](https://github.com/licenses/license-templates/blob/master/templates/agpl3-header.txt)
+
+# How to add License
+When you create new file in `src/` directory, we need to add and check License header before your push.
+
+```shell
+cd starship
+make addlicense
+```
+
+> Note: skywalking-eyes will add license directly and does not support override License header so far.
+
+# How to check license
+
+```shell
+cd starship
+make checklicense
+```
+
+# License check Pipline
+starship use Github actions as License Check Pipeline defined in `.github/license-check.yaml`.

--- a/src/agent/cmd/agent_image_test.go
+++ b/src/agent/cmd/agent_image_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package main
 
 import (

--- a/src/agent/cmd/agent_image_test.go
+++ b/src/agent/cmd/agent_image_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/cmd/main.go
+++ b/src/agent/cmd/main.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package main
 
 import (

--- a/src/agent/cmd/main.go
+++ b/src/agent/cmd/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/deployer/deployer.go
+++ b/src/agent/deployer/deployer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/deployer/deployer.go
+++ b/src/agent/deployer/deployer.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // Package deployer implements the agent's logic for connecting to the API Server's ModuleDeployer service.
 package deployer
 

--- a/src/agent/deployer/deployer_test.go
+++ b/src/agent/deployer/deployer_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package deployer
 
 import (

--- a/src/agent/deployer/deployer_test.go
+++ b/src/agent/deployer/deployer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/driver/data_buffer.go
+++ b/src/agent/driver/data_buffer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/driver/data_buffer.go
+++ b/src/agent/driver/data_buffer.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package driver
 
 type DataBuffer struct {

--- a/src/agent/driver/module.go
+++ b/src/agent/driver/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/driver/module.go
+++ b/src/agent/driver/module.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package driver
 
 import (

--- a/src/agent/driver/module_test.go
+++ b/src/agent/driver/module_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/driver/module_test.go
+++ b/src/agent/driver/module_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package driver
 
 import (

--- a/src/agent/driver/queue.go
+++ b/src/agent/driver/queue.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/driver/queue.go
+++ b/src/agent/driver/queue.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package driver
 
 import (

--- a/src/agent/driver/queue_test.go
+++ b/src/agent/driver/queue_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/driver/queue_test.go
+++ b/src/agent/driver/queue_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package driver
 
 import (

--- a/src/agent/ebpf/bcc/bcc.go
+++ b/src/agent/ebpf/bcc/bcc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/ebpf/bcc/bcc.go
+++ b/src/agent/ebpf/bcc/bcc.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // Package bcc provides types and APIs for working with BCC-style eBPF C programs.
 // Largely wraps BCC's go binding.
 package bcc

--- a/src/agent/ebpf/bcc/bcc_test.go
+++ b/src/agent/ebpf/bcc/bcc_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package bcc
 
 import (

--- a/src/agent/ebpf/bcc/bcc_test.go
+++ b/src/agent/ebpf/bcc/bcc_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/ebpf/bcc/linux_headers/locate.go
+++ b/src/agent/ebpf/bcc/linux_headers/locate.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -158,13 +158,16 @@ func findKernelConfig(hostRootDir string, version Version, unameStr string) (str
 
 // genAutoConf generate auto conf base on kernel config
 // kernel config:
-//  CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
-//  CONFIG_CC_IS_GCC=y
-//  CONFIG_GCC_VERSION=120200
+//
+//	CONFIG_CC_VERSION_TEXT="gcc (GCC) 12.2.0"
+//	CONFIG_CC_IS_GCC=y
+//	CONFIG_GCC_VERSION=120200
+//
 // autoconf.h
-//  #define CONFIG_CC_VERSION_TEXT "gcc (GCC) 12.2.0"
-//  #define CONFIG_CC_IS_GCC 1
-//  #define CONFIG_GCC_VERSION 120200
+//
+//	#define CONFIG_CC_VERSION_TEXT "gcc (GCC) 12.2.0"
+//	#define CONFIG_CC_IS_GCC 1
+//	#define CONFIG_GCC_VERSION 120200
 func genAutoConf(packageHeaderDir, configFilePath string) (int, error) {
 	if !file.Exists(packageHeaderDir) {
 		return 0, fmt.Errorf("empty package header dir %s", packageHeaderDir)
@@ -247,12 +250,12 @@ func applyConfigPatches(hostRootDir, packageHeaderDir, starShipDir, unameStr str
 }
 
 // locateAndInstallPackagedHeaders that will find the Linux Kernel headers in the following order:
-// 1. search closest version from packaged header directory
-// 2. extract it to "/usr/src/linux-headers-<version>-starship" directory
-// 3. modify kernel version in "/usr/src/linux-headers-<version>-starship/include/generated/uapi/linux/version.h"
-// 4. apply config patches in "/usr/src/linux-headers-<version>-starship/include/generated/autoconf.h"
-//    and "/usr/src/linux-headers-<version>-starship/include/generated/timeconst.h"
-// 5. create a symlink from "/usr/src/linux-headers-<version>-starship" to "/usr/src/linux-headers-<version>/build"
+//  1. search closest version from packaged header directory
+//  2. extract it to "/usr/src/linux-headers-<version>-starship" directory
+//  3. modify kernel version in "/usr/src/linux-headers-<version>-starship/include/generated/uapi/linux/version.h"
+//  4. apply config patches in "/usr/src/linux-headers-<version>-starship/include/generated/autoconf.h"
+//     and "/usr/src/linux-headers-<version>-starship/include/generated/timeconst.h"
+//  5. create a symlink from "/usr/src/linux-headers-<version>-starship" to "/usr/src/linux-headers-<version>/build"
 func locateAndInstallPackageHeaders(hostRootDir, libModuleDir, starShipDir,
 	installHeadersDir, unameStr string, version Version,
 ) error {

--- a/src/agent/ebpf/bcc/linux_headers/locate.go
+++ b/src/agent/ebpf/bcc/linux_headers/locate.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package linux_headers
 
 import (

--- a/src/agent/ebpf/bcc/linux_headers/locate_test.go
+++ b/src/agent/ebpf/bcc/linux_headers/locate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/ebpf/bcc/linux_headers/locate_test.go
+++ b/src/agent/ebpf/bcc/linux_headers/locate_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package linux_headers
 
 import (

--- a/src/agent/ebpf/bcc/linux_headers/version.go
+++ b/src/agent/ebpf/bcc/linux_headers/version.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  Tricorder Observability
+// Copyright (C) 2023 Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/ebpf/bcc/linux_headers/version.go
+++ b/src/agent/ebpf/bcc/linux_headers/version.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/ebpf/bcc/linux_headers/version.go
+++ b/src/agent/ebpf/bcc/linux_headers/version.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package linux_headers
 
 import (

--- a/src/agent/ebpf/bcc/linux_headers/version_test.go
+++ b/src/agent/ebpf/bcc/linux_headers/version_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/ebpf/bcc/linux_headers/version_test.go
+++ b/src/agent/ebpf/bcc/linux_headers/version_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package linux_headers
 
 import (

--- a/src/agent/ebpf/bcc/perf_buffer.go
+++ b/src/agent/ebpf/bcc/perf_buffer.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package bcc
 
 import (

--- a/src/agent/ebpf/bcc/perf_buffer.go
+++ b/src/agent/ebpf/bcc/perf_buffer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/ebpf/bcc/program.go
+++ b/src/agent/ebpf/bcc/program.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package bcc
 
 import (

--- a/src/agent/ebpf/bcc/program.go
+++ b/src/agent/ebpf/bcc/program.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/ebpf/bcc/program_test.go
+++ b/src/agent/ebpf/bcc/program_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package bcc
 
 import (

--- a/src/agent/ebpf/bcc/program_test.go
+++ b/src/agent/ebpf/bcc/program_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/ebpf/bcc/utils/probe_cleaner.go
+++ b/src/agent/ebpf/bcc/utils/probe_cleaner.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -27,7 +27,7 @@ const (
 	// The path of kprobe files under /sys, join with the host sys root path to form the correct path inside container.
 	kprobeEventsSysRelPath = "kernel/debug/tracing/kprobe_events"
 	uprobeEventsSysRelPath = "kernel/debug/tracing/uprobe_events"
-	// https://github.com/tricorder-observability/bcc/commit/50de7107d6a48fcfe4f82d33433960f965d1a16a
+	// https://github.com/Tricorder Observability/bcc/commit/50de7107d6a48fcfe4f82d33433960f965d1a16a
 	// Marker is set here.
 	tricorderMarker = "__tricorder__"
 )

--- a/src/agent/ebpf/bcc/utils/probe_cleaner.go
+++ b/src/agent/ebpf/bcc/utils/probe_cleaner.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package utils
 
 import (

--- a/src/agent/ebpf/bcc/utils/probe_cleaner_test.go
+++ b/src/agent/ebpf/bcc/utils/probe_cleaner_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/ebpf/bcc/utils/probe_cleaner_test.go
+++ b/src/agent/ebpf/bcc/utils/probe_cleaner_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package utils
 
 import (

--- a/src/agent/ebpf/common/perf_event.go
+++ b/src/agent/ebpf/common/perf_event.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/ebpf/common/perf_event.go
+++ b/src/agent/ebpf/common/perf_event.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package common
 
 // perf_event.go defines enums for attaching perf events.

--- a/src/agent/proc_info/pid_collector.go
+++ b/src/agent/proc_info/pid_collector.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package proc_info
 
 import (

--- a/src/agent/proc_info/pid_collector.go
+++ b/src/agent/proc_info/pid_collector.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -109,10 +109,10 @@ func (c *Collector) StartProcInfoReport() error {
 // Inject outer-scope hostname into container, so the agent can use this to filter out updates not relevant to this node
 // from the K8s API server.
 // env:
-// - name: NODE_NAME
-//   valueFrom:
-//	   fieldRef:
-//	     fieldPath: spec.nodeName
+//   - name: NODE_NAME
+//     valueFrom:
+//     fieldRef:
+//     fieldPath: spec.nodeName
 func GetNodeName() string {
 	return os.Getenv("NODE_NAME")
 }

--- a/src/agent/proc_info/pid_collector_test.go
+++ b/src/agent/proc_info/pid_collector_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/proc_info/pid_collector_test.go
+++ b/src/agent/proc_info/pid_collector_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package proc_info
 
 import (

--- a/src/agent/wasm/memory.go
+++ b/src/agent/wasm/memory.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/wasm/memory.go
+++ b/src/agent/wasm/memory.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package wasm
 
 import (

--- a/src/agent/wasm/memory_layout_test.go
+++ b/src/agent/wasm/memory_layout_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/wasm/memory_layout_test.go
+++ b/src/agent/wasm/memory_layout_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package wasm
 
 import (

--- a/src/agent/wasm/memory_test.go
+++ b/src/agent/wasm/memory_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/wasm/memory_test.go
+++ b/src/agent/wasm/memory_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package wasm
 
 import (

--- a/src/agent/wasm/module.go
+++ b/src/agent/wasm/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/wasm/module.go
+++ b/src/agent/wasm/module.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // Package wasm wraps Wasmtime-Go's Golang binding of the C/C++ Wasmtime API.
 package wasm
 

--- a/src/agent/wasm/module_test.go
+++ b/src/agent/wasm/module_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/wasm/module_test.go
+++ b/src/agent/wasm/module_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package wasm
 
 import (

--- a/src/agent/wasm/programs/Makefile
+++ b/src/agent/wasm/programs/Makefile
@@ -1,4 +1,4 @@
-# Copyright (C) 2023  tricorder-observability
+# Copyright (C) 2023  Tricorder Observability
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/wasm/programs/Makefile
+++ b/src/agent/wasm/programs/Makefile
@@ -1,3 +1,18 @@
+# Copyright (C) 2023  tricorder-observability
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 all: struct_test.wasm
 
 WASI_CLANG := WASI_SDK_PATH=/opt/wasi-sdk /opt/wasi-sdk/bin/clang

--- a/src/agent/wasm/programs/cgo/event.go
+++ b/src/agent/wasm/programs/cgo/event.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/wasm/programs/cgo/event.go
+++ b/src/agent/wasm/programs/cgo/event.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package cgo
 
 /*

--- a/src/agent/wasm/programs/cgo/ints.go
+++ b/src/agent/wasm/programs/cgo/ints.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/wasm/programs/cgo/ints.go
+++ b/src/agent/wasm/programs/cgo/ints.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package cgo
 
 /*

--- a/src/agent/wasm/programs/pico/Makefile
+++ b/src/agent/wasm/programs/pico/Makefile
@@ -1,4 +1,4 @@
-# Copyright (C) 2023  tricorder-observability
+# Copyright (C) 2023  Tricorder Observability
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/wasm/programs/pico/Makefile
+++ b/src/agent/wasm/programs/pico/Makefile
@@ -1,3 +1,18 @@
+# Copyright (C) 2023  tricorder-observability
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 all: wasm wat go-wrapper
 
 native:

--- a/src/agent/wasm/utils.go
+++ b/src/agent/wasm/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/agent/wasm/utils.go
+++ b/src/agent/wasm/utils.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package wasm
 
 import (

--- a/src/api-server/cmd/api_server_image_test.go
+++ b/src/api-server/cmd/api_server_image_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package main
 
 import (

--- a/src/api-server/cmd/api_server_image_test.go
+++ b/src/api-server/cmd/api_server_image_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/cmd/main.go
+++ b/src/api-server/cmd/main.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package main
 
 import (

--- a/src/api-server/cmd/main.go
+++ b/src/api-server/cmd/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/dao/grafana_api_key.go
+++ b/src/api-server/dao/grafana_api_key.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/dao/grafana_api_key.go
+++ b/src/api-server/dao/grafana_api_key.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package dao
 
 import (

--- a/src/api-server/dao/grafana_api_key_test.go
+++ b/src/api-server/dao/grafana_api_key_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/dao/grafana_api_key_test.go
+++ b/src/api-server/dao/grafana_api_key_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package dao
 
 import (

--- a/src/api-server/dao/module.go
+++ b/src/api-server/dao/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/dao/module.go
+++ b/src/api-server/dao/module.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package dao
 
 import (

--- a/src/api-server/dao/module_test.go
+++ b/src/api-server/dao/module_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/dao/module_test.go
+++ b/src/api-server/dao/module_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package dao
 
 import (

--- a/src/api-server/dao/sqlite.go
+++ b/src/api-server/dao/sqlite.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/dao/sqlite.go
+++ b/src/api-server/dao/sqlite.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package dao
 
 import (

--- a/src/api-server/dao/sqlite_test.go
+++ b/src/api-server/dao/sqlite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/dao/sqlite_test.go
+++ b/src/api-server/dao/sqlite_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package dao
 
 import "testing"

--- a/src/api-server/grpc/deployer.go
+++ b/src/api-server/grpc/deployer.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package grpc
 
 import (

--- a/src/api-server/grpc/deployer.go
+++ b/src/api-server/grpc/deployer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/grpc/deployer_test.go
+++ b/src/api-server/grpc/deployer_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package grpc
 
 import (

--- a/src/api-server/grpc/deployer_test.go
+++ b/src/api-server/grpc/deployer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/grpc/pid_collector.go
+++ b/src/api-server/grpc/pid_collector.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package grpc
 
 import (

--- a/src/api-server/grpc/pid_collector.go
+++ b/src/api-server/grpc/pid_collector.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/grpc/pid_collector_test.go
+++ b/src/api-server/grpc/pid_collector_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package grpc
 
 import (

--- a/src/api-server/grpc/pid_collector_test.go
+++ b/src/api-server/grpc/pid_collector_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/http/cors.go
+++ b/src/api-server/http/cors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/http/cors.go
+++ b/src/api-server/http/cors.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package http
 
 import (

--- a/src/api-server/http/exception.go
+++ b/src/api-server/http/exception.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/http/exception.go
+++ b/src/api-server/http/exception.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package http
 
 import (

--- a/src/api-server/http/grafana.go
+++ b/src/api-server/http/grafana.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/http/grafana.go
+++ b/src/api-server/http/grafana.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package http
 
 import (

--- a/src/api-server/http/grafana/auth_token.go
+++ b/src/api-server/http/grafana/auth_token.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/http/grafana/auth_token.go
+++ b/src/api-server/http/grafana/auth_token.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package grafana
 
 import (

--- a/src/api-server/http/grafana/dashboard.go
+++ b/src/api-server/http/grafana/dashboard.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package grafana
 
 import (

--- a/src/api-server/http/grafana/dashboard.go
+++ b/src/api-server/http/grafana/dashboard.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -25,7 +25,7 @@ import (
 )
 
 // TODO(zhihui): Add tests with a running Grafana instance in docker container
-// https://github.com/tricorder-observability/starship/issues/534
+// https://github.com/Tricorder Observability/starship/issues/534
 // See this issue for some ideas
 
 type Dashboard struct {

--- a/src/api-server/http/grafana/datasource.go
+++ b/src/api-server/http/grafana/datasource.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/http/grafana/datasource.go
+++ b/src/api-server/http/grafana/datasource.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package grafana
 
 import (

--- a/src/api-server/http/grafana/global.go
+++ b/src/api-server/http/grafana/global.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package grafana
 
 // TODO(zhihui): Consider put these into a new type

--- a/src/api-server/http/grafana/global.go
+++ b/src/api-server/http/grafana/global.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -16,9 +16,10 @@
 package grafana
 
 // TODO(zhihui): Consider put these into a new type
-// type Client struct {
-//     ... base url, createAuthKey URI etc.
-// }
+//
+//	type Client struct {
+//	    ... base url, createAuthKey URI etc.
+//	}
 var (
 	BaseURL            string
 	CreateAuthKeysURI  string

--- a/src/api-server/http/grafana/grafana_test.go
+++ b/src/api-server/http/grafana/grafana_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/http/grafana/grafana_test.go
+++ b/src/api-server/http/grafana/grafana_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package grafana
 
 import (

--- a/src/api-server/http/grafana_test.go
+++ b/src/api-server/http/grafana_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/http/grafana_test.go
+++ b/src/api-server/http/grafana_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package http
 
 import (

--- a/src/api-server/http/http.go
+++ b/src/api-server/http/http.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/http/http.go
+++ b/src/api-server/http/http.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package http
 
 import (

--- a/src/api-server/http/module_manager.go
+++ b/src/api-server/http/module_manager.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/http/module_manager.go
+++ b/src/api-server/http/module_manager.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package http
 
 import (

--- a/src/api-server/http/module_manager_test.go
+++ b/src/api-server/http/module_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/http/module_manager_test.go
+++ b/src/api-server/http/module_manager_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package http
 
 import (

--- a/src/api-server/http/types.go
+++ b/src/api-server/http/types.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/http/types.go
+++ b/src/api-server/http/types.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package http
 
 import (

--- a/src/api-server/meta/meta.go
+++ b/src/api-server/meta/meta.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package meta
 
 import (

--- a/src/api-server/meta/meta.go
+++ b/src/api-server/meta/meta.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/meta/meta_test.go
+++ b/src/api-server/meta/meta_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package meta
 
 import (

--- a/src/api-server/meta/meta_test.go
+++ b/src/api-server/meta/meta_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/meta/resource_watcher.go
+++ b/src/api-server/meta/resource_watcher.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package meta
 
 import (

--- a/src/api-server/meta/resource_watcher.go
+++ b/src/api-server/meta/resource_watcher.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/meta/utils.go
+++ b/src/api-server/meta/utils.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package meta
 
 import (

--- a/src/api-server/meta/utils.go
+++ b/src/api-server/meta/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/testing/sqlite.go
+++ b/src/api-server/testing/sqlite.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/api-server/testing/sqlite.go
+++ b/src/api-server/testing/sqlite.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package testing
 
 import (

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -8,10 +8,10 @@ TODO(jian): we need to create a CD pipeline to release this CLI binary, so that 
 
 ```shell
 #Check the release page:
-#https://github.com/tricorder-observability/starship/releases
+#https://github.com/Tricorder Observability/starship/releases
 
-export STARSHIP_VERSION=`curl https://github.com/tricorder-observability/starship-cli/releases/latest  -Ls -o /dev/null -w %{url_effective} | grep -oE "[^/]+$"`
-curl -LO https://github.com/tricorder-observability/starship-cli/releases/download/$STARSHIP_VERSION/starship-cli_${STARSHIP_VERSION}_linux_amd64.tar.gz
+export STARSHIP_VERSION=`curl https://github.com/Tricorder Observability/starship-cli/releases/latest  -Ls -o /dev/null -w %{url_effective} | grep -oE "[^/]+$"`
+curl -LO https://github.com/Tricorder Observability/starship-cli/releases/download/$STARSHIP_VERSION/starship-cli_${STARSHIP_VERSION}_linux_amd64.tar.gz
 tar -xvf starship-cli_${STARSHIP_VERSION}_linux_amd64.tar.gz  -C /usr/local/bin/
 
 starship-cli -h
@@ -20,7 +20,7 @@ starship-cli -h
 - Build binary from source
 
 ```shell
-git clone https://github.com/tricorder-observability/starship.git
+git clone https://github.com/Tricorder Observability/starship.git
 
 cd starship
 

--- a/src/cli/cmd/module/create.go
+++ b/src/cli/cmd/module/create.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/cmd/module/create.go
+++ b/src/cli/cmd/module/create.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package module
 
 import (

--- a/src/cli/cmd/module/delete.go
+++ b/src/cli/cmd/module/delete.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/cmd/module/delete.go
+++ b/src/cli/cmd/module/delete.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package module
 
 import (

--- a/src/cli/cmd/module/deploy.go
+++ b/src/cli/cmd/module/deploy.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/cmd/module/deploy.go
+++ b/src/cli/cmd/module/deploy.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package module
 
 import (

--- a/src/cli/cmd/module/init.go
+++ b/src/cli/cmd/module/init.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/cmd/module/init.go
+++ b/src/cli/cmd/module/init.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package module
 
 import (

--- a/src/cli/cmd/module/list.go
+++ b/src/cli/cmd/module/list.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/cmd/module/list.go
+++ b/src/cli/cmd/module/list.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package module
 
 import (

--- a/src/cli/cmd/module/module.go
+++ b/src/cli/cmd/module/module.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/cmd/module/module.go
+++ b/src/cli/cmd/module/module.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package module
 
 import (

--- a/src/cli/cmd/module/undeploy.go
+++ b/src/cli/cmd/module/undeploy.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/cmd/module/undeploy.go
+++ b/src/cli/cmd/module/undeploy.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package module
 
 import (

--- a/src/cli/cmd/module/upload.go
+++ b/src/cli/cmd/module/upload.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/cmd/module/upload.go
+++ b/src/cli/cmd/module/upload.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package module
 
 import (

--- a/src/cli/cmd/root.go
+++ b/src/cli/cmd/root.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package cmd
 
 import (

--- a/src/cli/cmd/root.go
+++ b/src/cli/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/internal/model/response.go
+++ b/src/cli/internal/model/response.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/internal/model/response.go
+++ b/src/cli/internal/model/response.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package model
 
 // Response represents the api server response model.

--- a/src/cli/internal/outputs/json/json.go
+++ b/src/cli/internal/outputs/json/json.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/internal/outputs/json/json.go
+++ b/src/cli/internal/outputs/json/json.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package json
 
 import (

--- a/src/cli/internal/outputs/json/json_test.go
+++ b/src/cli/internal/outputs/json/json_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/internal/outputs/json/json_test.go
+++ b/src/cli/internal/outputs/json/json_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package json
 
 import (

--- a/src/cli/internal/outputs/output.go
+++ b/src/cli/internal/outputs/output.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package outputs
 
 import (

--- a/src/cli/internal/outputs/output.go
+++ b/src/cli/internal/outputs/output.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/internal/outputs/output_test.go
+++ b/src/cli/internal/outputs/output_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package outputs
 
 import (

--- a/src/cli/internal/outputs/output_test.go
+++ b/src/cli/internal/outputs/output_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/internal/outputs/table/table.go
+++ b/src/cli/internal/outputs/table/table.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/internal/outputs/table/table.go
+++ b/src/cli/internal/outputs/table/table.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package table
 
 import (

--- a/src/cli/internal/outputs/table/table_test.go
+++ b/src/cli/internal/outputs/table/table_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/internal/outputs/table/table_test.go
+++ b/src/cli/internal/outputs/table/table_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package table
 
 import (

--- a/src/cli/internal/outputs/yaml/yaml.go
+++ b/src/cli/internal/outputs/yaml/yaml.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/internal/outputs/yaml/yaml.go
+++ b/src/cli/internal/outputs/yaml/yaml.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package yaml
 
 import (

--- a/src/cli/internal/outputs/yaml/yaml_test.go
+++ b/src/cli/internal/outputs/yaml/yaml_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/internal/outputs/yaml/yaml_test.go
+++ b/src/cli/internal/outputs/yaml/yaml_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package yaml
 
 import (

--- a/src/cli/main.go
+++ b/src/cli/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/cli/main.go
+++ b/src/cli/main.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package main
 
 import "github.com/tricorder/src/cli/cmd"

--- a/src/testing/bazel/bazel.go
+++ b/src/testing/bazel/bazel.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/bazel/bazel.go
+++ b/src/testing/bazel/bazel.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package testing
 
 import (

--- a/src/testing/bazel/bazel_test.go
+++ b/src/testing/bazel/bazel_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/bazel/bazel_test.go
+++ b/src/testing/bazel/bazel_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package testing
 
 import (

--- a/src/testing/docker/cli.go
+++ b/src/testing/docker/cli.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/docker/cli.go
+++ b/src/testing/docker/cli.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package testing
 
 import (

--- a/src/testing/docker/cli_test.go
+++ b/src/testing/docker/cli_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/docker/cli_test.go
+++ b/src/testing/docker/cli_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package testing
 
 import (

--- a/src/testing/docker/runner.go
+++ b/src/testing/docker/runner.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/docker/runner.go
+++ b/src/testing/docker/runner.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package testing
 
 import (

--- a/src/testing/docker/runner_test.go
+++ b/src/testing/docker/runner_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/docker/runner_test.go
+++ b/src/testing/docker/runner_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package testing
 
 import (

--- a/src/testing/docker/testdata/main.go
+++ b/src/testing/docker/testdata/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/docker/testdata/main.go
+++ b/src/testing/docker/testdata/main.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package main
 
 import "fmt"

--- a/src/testing/grafana/fixture.go
+++ b/src/testing/grafana/fixture.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/grafana/fixture.go
+++ b/src/testing/grafana/fixture.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package grafana
 
 import (

--- a/src/testing/pg/fixture.go
+++ b/src/testing/pg/fixture.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -42,9 +42,10 @@ func init() {
 // You can then destroy the fixtures by deferring statement:
 // cleaner, pgClient, err := createPGTestFixutre()
 // require.Nil(err)
-// defer func() {
-//   assert.Nil(cleaner())
-// }()
+//
+//	defer func() {
+//	  assert.Nil(cleaner())
+//	}()
 func LaunchContainer() (func() error, *pgutils.Client, error) {
 	pgRunner := &docker.Runner{
 		ImageName: postgresImageName,

--- a/src/testing/pg/fixture.go
+++ b/src/testing/pg/fixture.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package pg
 
 import (

--- a/src/testing/promscale/fixture.go
+++ b/src/testing/promscale/fixture.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package promscale
 
 import (

--- a/src/testing/promscale/fixture.go
+++ b/src/testing/promscale/fixture.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/sys/env_var.go
+++ b/src/testing/sys/env_var.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/sys/env_var.go
+++ b/src/testing/sys/env_var.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package sys
 
 import (

--- a/src/testing/sys/env_var_test.go
+++ b/src/testing/sys/env_var_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/sys/env_var_test.go
+++ b/src/testing/sys/env_var_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package sys
 
 import (

--- a/src/testing/sys/stdout.go
+++ b/src/testing/sys/stdout.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/sys/stdout.go
+++ b/src/testing/sys/stdout.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package sys
 
 import (

--- a/src/testing/timescaledb/fixture.go
+++ b/src/testing/timescaledb/fixture.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/testing/timescaledb/fixture.go
+++ b/src/testing/timescaledb/fixture.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package timescale
 
 import (

--- a/src/utils/bytes/trim.go
+++ b/src/utils/bytes/trim.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/bytes/trim.go
+++ b/src/utils/bytes/trim.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package bytes
 
 import "bytes"

--- a/src/utils/bytes/trim_test.go
+++ b/src/utils/bytes/trim_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/bytes/trim_test.go
+++ b/src/utils/bytes/trim_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package bytes
 
 import (

--- a/src/utils/channel/channel.go
+++ b/src/utils/channel/channel.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/channel/channel.go
+++ b/src/utils/channel/channel.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package channel
 
 import (

--- a/src/utils/channel/channel_test.go
+++ b/src/utils/channel/channel_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/channel/channel_test.go
+++ b/src/utils/channel/channel_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package channel
 
 import (

--- a/src/utils/common/abs.go
+++ b/src/utils/common/abs.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/common/abs.go
+++ b/src/utils/common/abs.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package common
 
 // TODO(yzhao): Use generic

--- a/src/utils/common/rand_str.go
+++ b/src/utils/common/rand_str.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package common
 
 import (

--- a/src/utils/common/rand_str.go
+++ b/src/utils/common/rand_str.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/common/rand_str_test.go
+++ b/src/utils/common/rand_str_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package common
 
 import (

--- a/src/utils/common/rand_str_test.go
+++ b/src/utils/common/rand_str_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/common/str_trim.go
+++ b/src/utils/common/str_trim.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package common
 
 // StrTrimPrefix returns a string with the leading l chars removed.

--- a/src/utils/common/str_trim.go
+++ b/src/utils/common/str_trim.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/common/str_trim_test.go
+++ b/src/utils/common/str_trim_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package common
 
 import (

--- a/src/utils/common/str_trim_test.go
+++ b/src/utils/common/str_trim_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/errors/wrap.go
+++ b/src/utils/errors/wrap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/errors/wrap.go
+++ b/src/utils/errors/wrap.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package errors
 
 import "fmt"

--- a/src/utils/errors/wrap_test.go
+++ b/src/utils/errors/wrap_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/errors/wrap_test.go
+++ b/src/utils/errors/wrap_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package errors
 
 import (

--- a/src/utils/exec/command.go
+++ b/src/utils/exec/command.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/exec/command.go
+++ b/src/utils/exec/command.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package exec
 
 import (

--- a/src/utils/exec/command_test.go
+++ b/src/utils/exec/command_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/exec/command_test.go
+++ b/src/utils/exec/command_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package exec
 
 import "testing"

--- a/src/utils/exec/run.go
+++ b/src/utils/exec/run.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/exec/run.go
+++ b/src/utils/exec/run.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package exec
 
 import (

--- a/src/utils/file/file.go
+++ b/src/utils/file/file.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // Package file provides utility APIs for interacting with file system
 package file
 

--- a/src/utils/file/file.go
+++ b/src/utils/file/file.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/file/file_test.go
+++ b/src/utils/file/file_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package file
 
 import (

--- a/src/utils/file/file_test.go
+++ b/src/utils/file/file_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/http/api.go
+++ b/src/utils/http/api.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/http/api.go
+++ b/src/utils/http/api.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package http
 
 import (

--- a/src/utils/http/gen.go
+++ b/src/utils/http/gen.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // Package http provides API to generate random HTTP requests
 package http
 

--- a/src/utils/http/gen.go
+++ b/src/utils/http/gen.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/http/gen_test.go
+++ b/src/utils/http/gen_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/http/gen_test.go
+++ b/src/utils/http/gen_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package http
 
 import (

--- a/src/utils/log/log.go
+++ b/src/utils/log/log.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/log/log.go
+++ b/src/utils/log/log.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // Package log initialize logurs
 package log
 

--- a/src/utils/parser/http/http.go
+++ b/src/utils/parser/http/http.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/parser/http/http.go
+++ b/src/utils/parser/http/http.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // Package http provides basic parsing API for HTTP network traffic.
 package http
 

--- a/src/utils/parser/http/http_test.go
+++ b/src/utils/parser/http/http_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/parser/http/http_test.go
+++ b/src/utils/parser/http/http_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package http
 
 import (

--- a/src/utils/pb/pb_test.go
+++ b/src/utils/pb/pb_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package pb
 
 import (

--- a/src/utils/pb/pb_test.go
+++ b/src/utils/pb/pb_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/pb/text_format.go
+++ b/src/utils/pb/text_format.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package pb
 
 import (

--- a/src/utils/pb/text_format.go
+++ b/src/utils/pb/text_format.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/pb/text_format_test.go
+++ b/src/utils/pb/text_format_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package pb
 
 import (

--- a/src/utils/pb/text_format_test.go
+++ b/src/utils/pb/text_format_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/pg/client.go
+++ b/src/utils/pg/client.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // Package pg provides API to interact with a Postgres server.
 package pg
 

--- a/src/utils/pg/client.go
+++ b/src/utils/pg/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/pg/client_test.go
+++ b/src/utils/pg/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/pg/client_test.go
+++ b/src/utils/pg/client_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package pg
 
 import (

--- a/src/utils/pg/column.go
+++ b/src/utils/pg/column.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/pg/column.go
+++ b/src/utils/pg/column.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package pg
 
 import (

--- a/src/utils/pg/column_test.go
+++ b/src/utils/pg/column_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/pg/column_test.go
+++ b/src/utils/pg/column_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package pg
 
 import (

--- a/src/utils/pg/schemas.go
+++ b/src/utils/pg/schemas.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/pg/schemas.go
+++ b/src/utils/pg/schemas.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package pg
 
 import "github.com/tricorder/src/pb/module/common"

--- a/src/utils/pg/schemas_test.go
+++ b/src/utils/pg/schemas_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/pg/schemas_test.go
+++ b/src/utils/pg/schemas_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package pg
 
 import (

--- a/src/utils/pg/utils.go
+++ b/src/utils/pg/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/pg/utils.go
+++ b/src/utils/pg/utils.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package pg
 
 import "strings"

--- a/src/utils/pg/utils_test.go
+++ b/src/utils/pg/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/pg/utils_test.go
+++ b/src/utils/pg/utils_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package pg
 
 import (

--- a/src/utils/pg/writer/main.go
+++ b/src/utils/pg/writer/main.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package main
 
 import (

--- a/src/utils/pg/writer/main.go
+++ b/src/utils/pg/writer/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/retry/retry.go
+++ b/src/utils/retry/retry.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/retry/retry.go
+++ b/src/utils/retry/retry.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // Package retry provides API to retry a function if it fails.
 package retry
 

--- a/src/utils/sqlite/gorm.go
+++ b/src/utils/sqlite/gorm.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package sqlite
 
 import (

--- a/src/utils/sqlite/gorm.go
+++ b/src/utils/sqlite/gorm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/sqlite/gorm_test.go
+++ b/src/utils/sqlite/gorm_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package sqlite
 
 import (

--- a/src/utils/sqlite/gorm_test.go
+++ b/src/utils/sqlite/gorm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/sqlite/sqlite.go
+++ b/src/utils/sqlite/sqlite.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package sqlite
 
 import (

--- a/src/utils/sqlite/sqlite.go
+++ b/src/utils/sqlite/sqlite.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/sqlite/sqlite_test.go
+++ b/src/utils/sqlite/sqlite_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package sqlite
 
 import (

--- a/src/utils/sqlite/sqlite_test.go
+++ b/src/utils/sqlite/sqlite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/tar/tar.go
+++ b/src/utils/tar/tar.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/tar/tar.go
+++ b/src/utils/tar/tar.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package tar
 
 import (

--- a/src/utils/tar/tar_test.go
+++ b/src/utils/tar/tar_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/tar/tar_test.go
+++ b/src/utils/tar/tar_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package tar
 
 import (

--- a/src/utils/timer/timer.go
+++ b/src/utils/timer/timer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/timer/timer.go
+++ b/src/utils/timer/timer.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package timer
 
 import "time"

--- a/src/utils/uuid/uuid.go
+++ b/src/utils/uuid/uuid.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/uuid/uuid.go
+++ b/src/utils/uuid/uuid.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package uuid
 
 import (

--- a/src/utils/uuid/uuid_test.go
+++ b/src/utils/uuid/uuid_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023  tricorder-observability
+// Copyright (C) 2023  Tricorder Observability
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/utils/uuid/uuid_test.go
+++ b/src/utils/uuid/uuid_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  tricorder-observability
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package uuid
 
 import (

--- a/tools/cleanup.sh
+++ b/tools/cleanup.sh
@@ -43,3 +43,8 @@ print_divider
 echo "Running check_readme ..."
 print_divider
 .github/scripts/check_readme.sh
+
+echo
+print_divider
+echo "Running check_license ..."
+make -C devops/license/ addlicense


### PR DESCRIPTION
fix https://github.com/tricorder-observability/starship/issues/48

1. install `license-eys` cli
```bash
go install github.com/apache/skywalking-eyes/cmd/license-eye@latest
```

2. update `.licenserc.yaml` 
3. then, fix license header
```bash
license-eye -c .licenserc.yaml header fix  
```