### PR TITLE
Chore: add docker hub push

### DIFF
--- a/.github/workflows/release-dev-images.yaml
+++ b/.github/workflows/release-dev-images.yaml
@@ -36,16 +36,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: bazelbuild/setup-bazelisk@v2
-      - name: Build and push starship api-server image to Github Packages
-        run: bazel run --define=TAG=${TAG} --define=REGISTRY=${REGISTRY} //src/api-server/cmd:push_api-server_image
-        working-directory: .
       - name: Login to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           #registry: docker.io
           username: ${{ secrets.DOCKER_HUB_USER_NAME }}
           password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
+      - uses: bazelbuild/setup-bazelisk@v2
+      - name: Build and push starship api-server image to Github Packages
+        run: bazel run --define=TAG=${TAG} --define=REGISTRY=${REGISTRY} //src/api-server/cmd:push_api-server_image
+        working-directory: .
       - name: Build and push starship api-server image to Docker hub
         run: bazel run --define=TAG=${TAG} --define=REGISTRY=${DOCKER_HUB_REGISTRY} //src/api-server/cmd:push_api-server_image
         working-directory: .

--- a/.github/workflows/release-dev-images.yaml
+++ b/.github/workflows/release-dev-images.yaml
@@ -43,7 +43,7 @@ jobs:
         run: bazel run --define=TAG=${TAG} --define=REGISTRY=${REGISTRY} //src/api-server/cmd:push_api-server_image
         working-directory: .
       - name: Docker tag
-        run: docker tag ${REGISTRY}/api-server:${TAG} ${{ env.REGISTRY }}/api-server:${TAG} 
+        run: docker tag ${REGISTRY}/api-server:${TAG} ${{ env.DOCKER_HUB_REGISTRY }}/api-server:${TAG} 
       - name: Login to Docker Hub Registry
         uses: docker/login-action@v2.1.0
         with:
@@ -51,7 +51,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER_NAME }}
           password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
       - name: Push starship api-server image to Docker Hub
-        run: docker push ${{ env.REGISTRY }}/api-server:${TAG}
+        run: docker push ${{ env.DOCKER_HUB_REGISTRY }}/api-server:${TAG}
 
   build-agent-and-push-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-dev-images.yaml
+++ b/.github/workflows/release-dev-images.yaml
@@ -16,8 +16,6 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io/${{ github.repository_owner }}
-  REGISTRY_USER_NAME: ${{ github.repository_owner }}
-  REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
   DOCKER_HUB_REGISTRY: docker.io/tricorderobservability
 
 jobs:
@@ -42,10 +40,10 @@ jobs:
       - name: Build and push starship api-server image to Github Packages
         run: bazel run --define=TAG=${TAG} --define=REGISTRY=${REGISTRY} //src/api-server/cmd:push_api-server_image
         working-directory: .
-      - name: Login to Docker Hub Registry
-        uses: docker/login-action@v2.1.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
-          registry: docker.io
+          #registry: docker.io
           username: ${{ secrets.DOCKER_HUB_USER_NAME }}
           password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
       - name: Build and push starship api-server image to Docker hub

--- a/.github/workflows/release-dev-images.yaml
+++ b/.github/workflows/release-dev-images.yaml
@@ -42,8 +42,8 @@ jobs:
       - name: Build and push starship api-server image
         run: bazel run --define=TAG=${TAG} --define=REGISTRY=${REGISTRY} //src/api-server/cmd:push_api-server_image
         working-directory: .
-      - name: Docker tag ${REGISTRY}/api-server:${TAG} ${{ env.REGISTRY }}/api-server:${TAG}
-        run: docker tag 
+      - name: Docker tag
+        run: docker tag ${REGISTRY}/api-server:${TAG} ${{ env.REGISTRY }}/api-server:${TAG} 
       - name: Login to Docker Hub Registry
         uses: docker/login-action@v2.1.0
         with:

--- a/.github/workflows/release-dev-images.yaml
+++ b/.github/workflows/release-dev-images.yaml
@@ -39,21 +39,18 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: bazelbuild/setup-bazelisk@v2
-      - name: Build and push starship api-server image
-        run: bazel run --define=TAG=${TAG} --define=REGISTRY=${REGISTRY} //src/api-server/cmd:api-server_image
+      - name: Build and push starship api-server image to Github Packages
+        run: bazel run --define=TAG=${TAG} --define=REGISTRY=${REGISTRY} //src/api-server/cmd:push_api-server_image
         working-directory: .
-      - name: Docker tag
-        run: docker tag ${REGISTRY}/api-server:${TAG} ${{ env.DOCKER_HUB_REGISTRY }}/api-server:${TAG} 
       - name: Login to Docker Hub Registry
         uses: docker/login-action@v2.1.0
         with:
           registry: docker.io
           username: ${{ secrets.DOCKER_HUB_USER_NAME }}
           password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
-      - name: Push starship api-server image to Docker Hub
-        run: |
-          docker push ${REGISTRY}/api-server:${TAG}
-          docker push ${{ env.DOCKER_HUB_REGISTRY }}/api-server:${TAG}
+      - name: Build and push starship api-server image to Docker hub
+        run: bazel run --define=TAG=${TAG} --define=REGISTRY=${DOCKER_HUB_REGISTRY} //src/api-server/cmd:push_api-server_image
+        working-directory: .
 
   build-agent-and-push-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-dev-images.yaml
+++ b/.github/workflows/release-dev-images.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  # TODO(jian): delete this.
+  pull_request:
+    branches:
+      - main
 # no dependencies between jobs, so we can save time by building in concurrency
 # refs: https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:

--- a/.github/workflows/release-dev-images.yaml
+++ b/.github/workflows/release-dev-images.yaml
@@ -37,7 +37,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2.1.0
         with:
           #registry: docker.io
           username: ${{ secrets.DOCKER_HUB_USER_NAME }}
@@ -67,9 +67,18 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+          #registry: docker.io
+          username: ${{ secrets.DOCKER_HUB_USER_NAME }}
+          password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
       - uses: bazelbuild/setup-bazelisk@v2
       - name: Build and push starship agent image
         run: bazel run --define=TAG=${TAG} --sandbox_debug --define=REGISTRY=${REGISTRY} //src/agent/cmd:push_agent_image
+        working-directory: .
+      - name: Build and push starship agent image to Docker hub
+        run: bazel run --define=TAG=${TAG} --define=REGISTRY=${DOCKER_HUB_REGISTRY} //src/agent/cmd:push_agent_image
         working-directory: .
 
   build-ui-and-push-images:
@@ -93,13 +102,6 @@ jobs:
           #registry: docker.io
           username: ${{ secrets.DOCKER_HUB_USER_NAME }}
           password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: |
-            ${{ env.DOCKER_HUB_REGISTRY }}/mgmt-ui:${{ env.TAG }}
-            ${{ env.REGISTRY }}/mgmt-ui:${{ env.TAG }}
       - name: Set Node.js 16.x
         uses: actions/setup-node@v3
         with:
@@ -120,5 +122,8 @@ jobs:
           push: true
           file: ./ui/docker/Dockerfile
           context: ./ui
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REGISTRY }}/mgmt-ui:${{ env.TAG }}
+      - name: Docker tag
+        run: docker tag ${{ env.REGISTRY }}/mgmt-ui:${{ env.TAG }} ${{ env.DOCKER_HUB_REGISTRY }}/mgmt-ui:${{ env.TAG }} 
+      - name: Push mgmt-ui image to Docker hub
+        run: docker push ${{ env.DOCKER_HUB_REGISTRY }}/mgmt-ui:${{ env.TAG }} 

--- a/.github/workflows/release-dev-images.yaml
+++ b/.github/workflows/release-dev-images.yaml
@@ -40,7 +40,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: bazelbuild/setup-bazelisk@v2
       - name: Build and push starship api-server image
-        run: bazel run --define=TAG=${TAG} --define=REGISTRY=${REGISTRY} //src/api-server/cmd:push_api-server_image
+        run: bazel run --define=TAG=${TAG} --define=REGISTRY=${REGISTRY} //src/api-server/cmd:api-server_image
         working-directory: .
       - name: Docker tag
         run: docker tag ${REGISTRY}/api-server:${TAG} ${{ env.DOCKER_HUB_REGISTRY }}/api-server:${TAG} 
@@ -51,7 +51,9 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER_NAME }}
           password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
       - name: Push starship api-server image to Docker Hub
-        run: docker push ${{ env.DOCKER_HUB_REGISTRY }}/api-server:${TAG}
+        run: |
+          docker push ${REGISTRY}/api-server:${TAG}
+          docker push ${{ env.DOCKER_HUB_REGISTRY }}/api-server:${TAG}
 
   build-agent-and-push-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-dev-images.yaml
+++ b/.github/workflows/release-dev-images.yaml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-  # TODO(jian): delete this.
-  pull_request:
-    branches:
-      - main
 # no dependencies between jobs, so we can save time by building in concurrency
 # refs: https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:

--- a/.github/workflows/release-dev-images.yaml
+++ b/.github/workflows/release-dev-images.yaml
@@ -14,6 +14,7 @@ env:
   REGISTRY: ghcr.io/${{ github.repository_owner }}
   REGISTRY_USER_NAME: ${{ github.repository_owner }}
   REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+  DOCKER_HUB_REGISTRY: docker.io/tricorderobservability
 
 jobs:
   build-apiserver-and-push-images:
@@ -37,6 +38,16 @@ jobs:
       - name: Build and push starship api-server image
         run: bazel run --define=TAG=${TAG} --define=REGISTRY=${REGISTRY} //src/api-server/cmd:push_api-server_image
         working-directory: .
+      - name: Docker tag ${REGISTRY}/api-server:${TAG} ${{ env.REGISTRY }}/api-server:${TAG}
+        run: docker tag 
+      - name: Login to Docker Hub Registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_HUB_USER_NAME }}
+          password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
+      - name: Push starship api-server image to Docker Hub
+        run: docker push ${{ env.REGISTRY }}/api-server:${TAG}
 
   build-agent-and-push-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-dev-images.yaml
+++ b/.github/workflows/release-dev-images.yaml
@@ -87,6 +87,19 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          #registry: docker.io
+          username: ${{ secrets.DOCKER_HUB_USER_NAME }}
+          password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: |
+            ${{ env.DOCKER_HUB_REGISTRY }}/mgmt-ui:${{ env.TAG }}
+            ${{ env.REGISTRY }}/mgmt-ui:${{ env.TAG }}
       - name: Set Node.js 16.x
         uses: actions/setup-node@v3
         with:
@@ -107,4 +120,5 @@ jobs:
           push: true
           file: ./ui/docker/Dockerfile
           context: ./ui
-          tags: ${{ env.REGISTRY }}/mgmt-ui:${{ env.TAG }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
close https://github.com/tricorder-observability/starship/issues/72

we will push docker images to both github packages and docker hub.
As for China mainland users, they can and often use docker hub mirrors to speed up the image pulling.
So, I will add some notes in `helm charts` to describe our `docker hub` repo in next PR.