### PR TITLE
Cleanup: update ci images with docker hub images

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
     # only run there are changed files
     if: needs.query-changed-src-files.outputs.any_changed == 'true'
     container:
-      image: public.ecr.aws/tricorder/ci_image:202302140538
+      image: docker.io/tricorderobservability/ci_image:202302140538
       options: --privileged
       volumes:
         # Needed for accessing kernel headers
@@ -93,7 +93,7 @@ jobs:
     # only run there are changed files
     if: needs.query-changed-src-files.outputs.any_changed == 'true'
     container:
-      image: public.ecr.aws/tricorder/ci_image:202302140538
+      image: docker.io/tricorderobservability/ci_image:202302140538
       options: --privileged
       volumes:
         # Needed for accessing kernel headers
@@ -131,7 +131,7 @@ jobs:
     # only run there are changed files
     if: needs.query-changed-src-files.outputs.any_changed == 'true'
     container:
-      image: public.ecr.aws/tricorder/ci_image:202302140538
+      image: docker.io/tricorderobservability/ci_image:202302140538
       options: --privileged
       volumes:
         # Needed to access /sys/kernel/tracing/kprobe
@@ -162,7 +162,7 @@ jobs:
   build-api-server-images:
     runs-on: ubuntu-latest
     container:
-      image: public.ecr.aws/tricorder/ci_image:202302140538
+      image: docker.io/tricorderobservability/ci_image:202302140538
     timeout-minutes: 90
     needs: build-and-test
     env:
@@ -177,7 +177,7 @@ jobs:
   build-agent-images:
     runs-on: ubuntu-latest
     container:
-      image: public.ecr.aws/tricorder/ci_image:202302140538
+      image: docker.io/tricorderobservability/ci_image:202302140538
     timeout-minutes: 90
     needs: build-and-test
     env:

--- a/.github/workflows/release-dev-images.yaml
+++ b/.github/workflows/release-dev-images.yaml
@@ -18,7 +18,7 @@ jobs:
   build-apiserver-and-push-images:
     runs-on: ubuntu-latest
     container:
-      image: public.ecr.aws/tricorder/ci_image:202302140538
+      image: docker.io/tricorderobservability/ci_image:202302140538
     timeout-minutes: 90
     permissions:
       packages: write
@@ -35,7 +35,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v2.1.0
         with:
-          #registry: docker.io
+          registry: docker.io
           username: ${{ secrets.DOCKER_HUB_USER_NAME }}
           password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
       - uses: bazelbuild/setup-bazelisk@v2
@@ -49,7 +49,7 @@ jobs:
   build-agent-and-push-images:
     runs-on: ubuntu-latest
     container:
-      image: public.ecr.aws/tricorder/ci_image:202302140538
+      image: docker.io/tricorderobservability/ci_image:202302140538
     timeout-minutes: 90
     permissions:
       packages: write
@@ -66,7 +66,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v2.1.0
         with:
-          #registry: docker.io
+          registry: docker.io
           username: ${{ secrets.DOCKER_HUB_USER_NAME }}
           password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
       - uses: bazelbuild/setup-bazelisk@v2
@@ -95,7 +95,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
-          #registry: docker.io
+          registry: docker.io
           username: ${{ secrets.DOCKER_HUB_USER_NAME }}
           password: ${{ secrets.DOCKER_HUB_USER_PASSWORD }}
       - name: Set Node.js 16.x

--- a/src/api-server/dao/node_agent.go
+++ b/src/api-server/dao/node_agent.go
@@ -77,7 +77,7 @@ func (g *NodeAgentDao) SaveAgent(agent *NodeAgentGORM) error {
 
 func (g *NodeAgentDao) UpdateByName(agent *NodeAgentGORM) error {
 	if len(agent.NodeName) == 0 {
-		return fmt.Errorf("name is empty")
+		return fmt.Errorf("name shuold not be empty")
 	}
 
 	agent.LastUpdateTime = &time.Time{}


### PR DESCRIPTION
a part of https://github.com/tricorder-observability/starship/issues/118