### PR TITLE
Spec(api-server): add undeploy test to grpc and fix DAO ModuleInstanceDao.UpdateStatusByID update zero bug

### DIFF
--- a/src/api-server/http/dao/module_instance.go
+++ b/src/api-server/http/dao/module_instance.go
@@ -97,14 +97,16 @@ func (g *ModuleInstanceDao) UpdateByID(module *ModuleInstanceGORM) error {
 	return result.Error
 }
 
-func (g *ModuleInstanceDao) UpdateStatusByID(ID string, statue int) error {
+func (g *ModuleInstanceDao) UpdateStatusByID(ID string, state int) error {
 	module := ModuleInstanceGORM{}
 
 	module.LastUpdateTime = &time.Time{}
 	*module.LastUpdateTime = time.Now()
-	module.State = statue
+	module.State = state
 
-	result := g.Client.Engine.Model(&ModuleInstanceGORM{}).Where("id", ID).Updates(module)
+	// use Select() to avoid update other fields and force update state 0 filed
+	result := g.Client.Engine.Model(&ModuleInstanceGORM{}).Where("id", ID).
+		Select("last_update_time", "state").Updates(module)
 	return result.Error
 }
 
@@ -115,7 +117,9 @@ func (g *ModuleInstanceDao) UpdateDesireStateByID(ID string, desireState int) er
 	*module.LastUpdateTime = time.Now()
 	module.DesireState = desireState
 
-	result := g.Client.Engine.Model(&ModuleInstanceGORM{}).Where("id", ID).Updates(module)
+	// use Select() to avoid update other fields and force update state 0 filed
+	result := g.Client.Engine.Model(&ModuleInstanceGORM{}).Where("id", ID).
+		Select("last_update_time", "desire_state").Updates(module)
 	return result.Error
 }
 

--- a/src/api-server/http/dao/module_instance_test.go
+++ b/src/api-server/http/dao/module_instance_test.go
@@ -102,10 +102,20 @@ func TestModuleInstance(t *testing.T) {
 
 	// test update module status
 	err = ModuleInstanceDao.UpdateStatusByID(moduleInstance.ID, int(pb.ModuleInstanceState_SUCCEEDED))
-	assert.Nil(err, "update moduleInstance status by ID error: %v", err)
+	assert.Nil(err)
+
+	// if status is 0, need to force update to 0, because 0 is default value
+	err = ModuleInstanceDao.UpdateStatusByID(moduleInstance.ID, int(pb.ModuleInstanceState_INIT))
+	assert.Nil(err)
+	moduleInstance, err = ModuleInstanceDao.QueryByID(moduleInstance.ID)
+	assert.Nil(err)
+	assert.Equal(moduleInstance.State, int(pb.ModuleInstanceState_INIT))
+
+	err = ModuleInstanceDao.UpdateStatusByID(moduleInstance.ID, int(pb.ModuleInstanceState_SUCCEEDED))
+	assert.Nil(err)
 
 	moduleInstance, err = ModuleInstanceDao.QueryByID(moduleInstance.ID)
-	assert.Nil(err, "query moduleInstance by ID error: %v", err)
+	assert.Nil(err)
 
 	// check node status
 	assert.Equal(moduleInstance.State, int(pb.ModuleInstanceState_SUCCEEDED),

--- a/src/api-server/http/dao/node_agent.go
+++ b/src/api-server/http/dao/node_agent.go
@@ -84,7 +84,8 @@ func (g *NodeAgentDao) UpdateStateByID(agentID string, statue int) error {
 	*agent.LastUpdateTime = time.Now()
 	agent.State = statue
 
-	result := g.Client.Engine.Model(&NodeAgentGORM{}).Where("agent_id", agentID).Updates(agent)
+	result := g.Client.Engine.Model(&NodeAgentGORM{}).Where("agent_id", agentID).
+		Select("state", "last_update_time").Updates(agent)
 	return result.Error
 }
 


### PR DESCRIPTION
# Describe your changes
add undeploy test to grpc, and fix DAO `ModuleInstanceDao.UpdateStatusByID` update state is zero is not working bug.

## Issue
- [x] https://github.com/tricorder-observability/Starship/issues/175

## Test:
- [ ] What tests are done for this PR
