### PR TITLE
chore(api-server): fix typo and todo comment style

### DIFF
--- a/src/api-server/http/api/api.go
+++ b/src/api-server/http/api/api.go
@@ -19,7 +19,7 @@ import "strings"
 
 // API path components.
 const (
-	// todo: change to resful style
+	// TODO(jun): change to resful style
 	ROOT            = "/api"
 	LIST_MODULE     = "/listModule"
 	LIST_AGENT      = "/listAgent"

--- a/src/api-server/http/client.go
+++ b/src/api-server/http/client.go
@@ -22,9 +22,9 @@ func NewClient(url string) *Client {
 	return &Client{url: url}
 }
 
-// ListAgent returns the list of agents stored on the API Server.
+// ListAgents returns the list of agents stored on the API Server.
 // agentReq is the request data structure, it will be converted to JSON and sent to the API Server.
-func (c *Client) ListAgent(agentReq *ListAgentReq) (*ListAgentResp, error) {
+func (c *Client) ListAgents(agentReq *ListAgentReq) (*ListAgentResp, error) {
 	field := "agent_id,node_name,agent_pod_id,state,create_time,last_update_time"
 	if agentReq != nil && len(agentReq.Fields) > 0 {
 		field = agentReq.Fields

--- a/src/api-server/http/client_test.go
+++ b/src/api-server/http/client_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/tricorder/src/utils/lock"
 )
 
-func TestListAgent(t *testing.T) {
+func TestListAgents(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -42,7 +42,7 @@ func TestListAgent(t *testing.T) {
 
 	// test list agent
 	client := NewClient("http://" + FakeHTTPServer.String())
-	res, err := client.ListAgent(nil)
+	res, err := client.ListAgents(nil)
 	require.NoError(err)
 	assert.Equal(200, res.Code)
 	assert.Equal(0, len(res.Data))
@@ -58,7 +58,7 @@ func TestListAgent(t *testing.T) {
 	err = nodeAgentDao.SaveAgent(&newAgent)
 	require.NoError(err)
 
-	res, err = client.ListAgent(nil)
+	res, err = client.ListAgents(nil)
 	require.NoError(err)
 	assert.Equal(200, res.Code)
 	assert.Equal(1, len(res.Data))

--- a/src/api-server/http/module_manager_test.go
+++ b/src/api-server/http/module_manager_test.go
@@ -303,6 +303,6 @@ func listAgent(t *testing.T, agentID string, r *gin.Engine) {
 	r.ServeHTTP(w, req)
 	resultStr := w.Body.String()
 	fmt.Printf("list agent: %s", resultStr)
-	// todo(jun): do not using t *testing.T in test helper, need to refactor this test for better readability
+	// TODO(jun): do not using t *testing.T in test helper, need to refactor this test for better readability
 	assert.Contains(resultStr, agentID)
 }

--- a/src/cli/cmd/agent/list.go
+++ b/src/cli/cmd/agent/list.go
@@ -33,7 +33,7 @@ var listCmd = &cobra.Command{
 		"$ starship-cli agent list --api-server=<address>",
 	Run: func(cmd *cobra.Command, args []string) {
 		client := apiserver.NewClient(apiServerAddress)
-		resp, err := client.ListAgent(nil)
+		resp, err := client.ListAgents(nil)
 		if err != nil {
 			log.Error(err)
 			return

--- a/src/cli/cmd/agent/list.go
+++ b/src/cli/cmd/agent/list.go
@@ -39,7 +39,7 @@ var listCmd = &cobra.Command{
 			return
 		}
 
-		// todo(jun): refactor output to delete this hack
+		// TODO(jun): refactor output to delete this hack
 		respByte, err := json.Marshal(resp)
 		if err != nil {
 			log.Error(err)


### PR DESCRIPTION
# Describe your changes
1. rename ListAgent to ListAgents
2. fix some `todo` style.

## Issue
None

## Test:
None
