### PR TITLE
Create Config for Grafana component and cleanup all caller code

### DIFF
--- a/src/api-server/http/client/BUILD.bazel
+++ b/src/api-server/http/client/BUILD.bazel
@@ -20,7 +20,6 @@ go_test(
         "//src/api-server/http",
         "//src/api-server/http/dao",
         "//src/api-server/http/fake",
-        "//src/api-server/http/grafana",
         "//src/api-server/pb",
         "//src/pb/module/common",
         "//src/pb/module/ebpf",

--- a/src/api-server/http/client/client_test.go
+++ b/src/api-server/http/client/client_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/tricorder/src/api-server/http"
 	"github.com/tricorder/src/api-server/http/dao"
 	"github.com/tricorder/src/api-server/http/fake"
-	"github.com/tricorder/src/api-server/http/grafana"
 	pb "github.com/tricorder/src/api-server/pb"
 	common "github.com/tricorder/src/pb/module/common"
 	"github.com/tricorder/src/pb/module/ebpf"
@@ -50,8 +49,6 @@ func TestListAgent(t *testing.T) {
 	cleanerFn, grafanaURL, err := grafanatest.LaunchContainer()
 	require.Nil(err)
 	defer func() { assert.Nil(cleanerFn()) }()
-
-	grafana.InitGrafanaConfig(grafanaURL, "admin", "admin")
 
 	pgClientCleanerFn, pgClient, err := pgclienttest.LaunchContainer()
 	require.Nil(err)
@@ -100,8 +97,6 @@ func TestCreateModule(t *testing.T) {
 	cleanerFn, grafanaURL, err := grafanatest.LaunchContainer()
 	require.Nil(err)
 	defer func() { assert.Nil(cleanerFn()) }()
-
-	grafana.InitGrafanaConfig(grafanaURL, "admin", "admin")
 
 	pgClientCleanerFn, pgClient, err := pgclienttest.LaunchContainer()
 	require.Nil(err)
@@ -176,8 +171,6 @@ func TestListModule(t *testing.T) {
 	require.Nil(err)
 	defer func() { assert.Nil(cleanerFn()) }()
 
-	grafana.InitGrafanaConfig(grafanaURL, "admin", "admin")
-
 	pgClientCleanerFn, pgClient, err := pgclienttest.LaunchContainer()
 	require.Nil(err)
 	defer func() { assert.Nil(pgClientCleanerFn()) }()
@@ -230,8 +223,6 @@ func TestDeleteModule(t *testing.T) {
 	cleanerFn, grafanaURL, err := grafanatest.LaunchContainer()
 	require.Nil(err)
 	defer func() { assert.Nil(cleanerFn()) }()
-
-	grafana.InitGrafanaConfig(grafanaURL, "admin", "admin")
 
 	pgClientCleanerFn, pgClient, err := pgclienttest.LaunchContainer()
 	require.Nil(err)
@@ -288,8 +279,6 @@ func TestDeployModule(t *testing.T) {
 	cleanerFn, grafanaURL, err := grafanatest.LaunchContainer()
 	require.Nil(err)
 	defer func() { assert.Nil(cleanerFn()) }()
-
-	grafana.InitGrafanaConfig(grafanaURL, "admin", "admin")
 
 	pgClientCleanerFn, pgClient, err := pgclienttest.LaunchContainer()
 	require.Nil(err)
@@ -363,8 +352,6 @@ func TestUndeployModule(t *testing.T) {
 	cleanerFn, grafanaURL, err := grafanatest.LaunchContainer()
 	require.Nil(err)
 	defer func() { assert.Nil(cleanerFn()) }()
-
-	grafana.InitGrafanaConfig(grafanaURL, "admin", "admin")
 
 	pgClientCleanerFn, pgClient, err := pgclienttest.LaunchContainer()
 	require.Nil(err)

--- a/src/api-server/http/grafana/BUILD.bazel
+++ b/src/api-server/http/grafana/BUILD.bazel
@@ -21,7 +21,6 @@ go_test(
     name = "grafana_test",
     srcs = ["grafana_test.go"],
     embed = [":grafana"],
-    tags = ["manual"],
     deps = [
         "//src/testing/grafana",
         "@com_github_stretchr_testify//assert",

--- a/src/api-server/http/grafana/BUILD.bazel
+++ b/src/api-server/http/grafana/BUILD.bazel
@@ -4,9 +4,9 @@ go_library(
     name = "grafana",
     srcs = [
         "auth_token.go",
+        "config.go",
         "dashboard.go",
         "datasource.go",
-        "global.go",
         "grafana.go",
     ],
     importpath = "github.com/tricorder/src/api-server/http/grafana",

--- a/src/api-server/http/grafana/auth_token.go
+++ b/src/api-server/http/grafana/auth_token.go
@@ -28,11 +28,13 @@ import (
 )
 
 type AuthToken struct {
+	config Config
 	client http.Client
 }
 
-func NewAuthToken() *AuthToken {
+func NewAuthToken(config Config) *AuthToken {
 	return &AuthToken{
+		config: config,
 		client: http.Client{},
 	}
 }
@@ -55,12 +57,12 @@ func (g *AuthToken) GetToken(apiPath string) (*AuthKeyResult, error) {
 
 	bytesData, _ := json.Marshal(data)
 
-	req, err := http.NewRequest("POST", CreateAuthKeysURI, bytes.NewReader(bytesData))
+	req, err := http.NewRequest("POST", g.config.CreateAuthKeysURI, bytes.NewReader(bytesData))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
-	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(BasicAuth)))
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(g.config.BasicAuth)))
 	resp, err := g.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -81,12 +83,12 @@ func (g *AuthToken) GetToken(apiPath string) (*AuthKeyResult, error) {
 
 // GetAllGrafanaAPIKey get all create grafana keys.
 func (g *AuthToken) GetAllGrafanaAPIKey() ([]AuthKeyResult, error) {
-	req, err := http.NewRequest("GET", CreateAuthKeysURI, strings.NewReader(""))
+	req, err := http.NewRequest("GET", g.config.CreateAuthKeysURI, strings.NewReader(""))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
-	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(BasicAuth)))
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(g.config.BasicAuth)))
 	resp, err := g.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -107,12 +109,12 @@ func (g *AuthToken) GetAllGrafanaAPIKey() ([]AuthKeyResult, error) {
 
 // RemoveGrafanaAPIKeyById remove exist grafana api key by id
 func (g *AuthToken) RemoveGrafanaAPIKeyById(ID int) error {
-	req, err := http.NewRequest("DELETE", CreateAuthKeysURI+"/"+strconv.Itoa(ID), strings.NewReader(""))
+	req, err := http.NewRequest("DELETE", g.config.CreateAuthKeysURI+"/"+strconv.Itoa(ID), strings.NewReader(""))
 	if err != nil {
 		return errors.Wrap("create grafana http request", "load", err)
 	}
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
-	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(BasicAuth)))
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(g.config.BasicAuth)))
 	resp, err := g.client.Do(req)
 	if err != nil {
 		return errors.Wrap("remove grafana api key", "load", err)

--- a/src/api-server/http/grafana/config.go
+++ b/src/api-server/http/grafana/config.go
@@ -28,11 +28,11 @@ type Config struct {
 func NewConfig(baseURL, userName, password string) Config {
 	// userName password come from command line flags
 	return Config{
-		BasicAuth:          userName + ":" + password,
 		BaseURL:            baseURL,
-		CreateAuthKeysURI:  BaseURL + "/api/auth/keys",
-		CreateDashBoardURI: BaseURL + "/api/dashboards/db",
-		CreateDatabaseURI:  BaseURL + "/api/datasources",
-		GetDashboardURI:    BaseURL + "/api/dashboards/uid/",
+		CreateAuthKeysURI:  baseURL + "/api/auth/keys",
+		CreateDashBoardURI: baseURL + "/api/dashboards/db",
+		CreateDatabaseURI:  baseURL + "/api/datasources",
+		GetDashboardURI:    baseURL + "/api/dashboards/uid/",
+		BasicAuth:          userName + ":" + password,
 	}
 }

--- a/src/api-server/http/grafana/config.go
+++ b/src/api-server/http/grafana/config.go
@@ -15,27 +15,24 @@
 
 package grafana
 
-// TODO(zhihui): Consider put these into a new type
-//
-//	type Client struct {
-//	    ... base url, createAuthKey URI etc.
-//	}
-var (
+type Config struct {
 	BaseURL            string
 	CreateAuthKeysURI  string
 	CreateDashBoardURI string
 	CreateDatabaseURI  string
 	GetDashboardURI    string
 	BasicAuth          string
-)
+}
 
-// InitGrafanaConfig initializes global configurations for how to connect with Grafana.
-func InitGrafanaConfig(baseURL, userName, password string) {
+// NewConfig initializes global configurations for how to connect with Grafana.
+func NewConfig(baseURL, userName, password string) Config {
 	// userName password come from command line flags
-	BasicAuth = userName + ":" + password
-	BaseURL = baseURL
-	CreateAuthKeysURI = BaseURL + "/api/auth/keys"
-	CreateDashBoardURI = BaseURL + "/api/dashboards/db"
-	CreateDatabaseURI = BaseURL + "/api/datasources"
-	GetDashboardURI = BaseURL + "/api/dashboards/uid/"
+	return Config{
+		BasicAuth:          userName + ":" + password,
+		BaseURL:            baseURL,
+		CreateAuthKeysURI:  BaseURL + "/api/auth/keys",
+		CreateDashBoardURI: BaseURL + "/api/dashboards/db",
+		CreateDatabaseURI:  BaseURL + "/api/datasources",
+		GetDashboardURI:    BaseURL + "/api/dashboards/uid/",
+	}
 }

--- a/src/api-server/http/grafana/dashboard.go
+++ b/src/api-server/http/grafana/dashboard.go
@@ -31,11 +31,13 @@ import (
 // See this issue for some ideas
 
 type Dashboard struct {
+	config Config
 	client http.Client
 }
 
-func NewDashboard() *Dashboard {
+func NewDashboard(config Config) *Dashboard {
 	return &Dashboard{
+		config: config,
 		client: http.Client{},
 	}
 }
@@ -80,7 +82,7 @@ func (g *Dashboard) CreateDashboard(createDashBoardAuthKey, title, datasourceUID
 
 	bytesData, _ := json.Marshal(bodyReq)
 
-	req, err := http.NewRequest("POST", CreateDashBoardURI, bytes.NewReader(bytesData))
+	req, err := http.NewRequest("POST", g.config.CreateDashBoardURI, bytes.NewReader(bytesData))
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +124,7 @@ func (g *Dashboard) AddDashboardPanel(
 
 	bytesData, _ := json.Marshal(bodyReq)
 
-	req, err := http.NewRequest("POST", CreateDashBoardURI, bytes.NewReader(bytesData))
+	req, err := http.NewRequest("POST", g.config.CreateDashBoardURI, bytes.NewReader(bytesData))
 	if err != nil {
 		return nil, err
 	}
@@ -149,12 +151,12 @@ func (g *Dashboard) AddDashboardPanel(
 
 // Returns a JSON string that describes the specified dashboard.
 func (g *Dashboard) GetDetailAsJSON(uid string) (string, error) {
-	req, err := http.NewRequest("GET", GetDashboardURI+uid, strings.NewReader(""))
+	req, err := http.NewRequest("GET", g.config.GetDashboardURI+uid, strings.NewReader(""))
 	if err != nil {
 		return "", errors.Wrap("getting dashboard detail", "create HTTP request", err)
 	}
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
-	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(BasicAuth)))
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(g.config.BasicAuth)))
 
 	resp, err := g.client.Do(req)
 	if err != nil {

--- a/src/api-server/http/grafana/datasource.go
+++ b/src/api-server/http/grafana/datasource.go
@@ -26,11 +26,13 @@ import (
 // TODO(zhihui): Add more comments to explain the purpose of these types and APIs.
 
 type Datasource struct {
+	config Config
 	client http.Client
 }
 
-func NewDatasource() *Datasource {
+func NewDatasource(config Config) *Datasource {
 	return &Datasource{
+		config: config,
 		client: http.Client{},
 	}
 }
@@ -58,7 +60,7 @@ func (g *Datasource) CreateDatasource(
 
 	bytesData, _ := json.Marshal(bodyReq)
 
-	req, err := http.NewRequest("POST", CreateDatabaseURI, bytes.NewReader(bytesData))
+	req, err := http.NewRequest("POST", g.config.CreateDatabaseURI, bytes.NewReader(bytesData))
 	if err != nil {
 		return nil, err
 	}

--- a/src/api-server/http/grafana/grafana.go
+++ b/src/api-server/http/grafana/grafana.go
@@ -22,14 +22,18 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-type GrafanaManagement struct{}
+type GrafanaManagement struct {
+	config Config
+}
 
 const DashboardAPIURL = "/api/dashboards/db"
 
 var grafanaAPIKeyMap = make(map[string]string)
 
-func NewGrafanaManagement() GrafanaManagement {
-	return GrafanaManagement{}
+func NewGrafanaManagement(config Config) GrafanaManagement {
+	return GrafanaManagement{
+		config: config,
+	}
 }
 
 func (g *GrafanaManagement) GetGrafanaKey(apiPath string) (string, error) {
@@ -37,7 +41,7 @@ func (g *GrafanaManagement) GetGrafanaKey(apiPath string) (string, error) {
 		return token, nil
 	}
 
-	authToken := NewAuthToken()
+	authToken := NewAuthToken(g.config)
 	allGrafanaAPIKey, err := authToken.GetAllGrafanaAPIKey()
 	if err != nil {
 		return "", errors.Wrap("get grafana all api token list", "load", err)

--- a/src/api-server/http/grafana/grafana_test.go
+++ b/src/api-server/http/grafana/grafana_test.go
@@ -41,14 +41,14 @@ func TestAuthToken(t *testing.T) {
 	}()
 
 	log.Println("grafana url:" + grafanaURL)
-	InitGrafanaConfig(grafanaURL, "admin", "admin")
-	authToken := NewAuthToken()
+	config := NewConfig(grafanaURL, "admin", "admin")
+	authToken := NewAuthToken(config)
 	require.NotNil(authToken)
 
 	token, err := authToken.GetToken("/api/dashboards/db")
 	assert.Nil(err)
 
-	dashboard := NewDashboard()
+	dashboard := NewDashboard(config)
 	assert.NotNil(dashboard)
 
 	result, err := dashboard.CreateDashboard(token.Key, "APIServer1", "uid")
@@ -62,11 +62,11 @@ func TestAuthToken(t *testing.T) {
 
 	datasourceToken, err := authToken.GetToken("/api/datasources")
 	require.Nil(err)
-	assert.Nil(createDatasource(datasourceToken.Key))
+	assert.Nil(createDatasource(config, datasourceToken.Key))
 }
 
-func createDatasource(token string) error {
-	ds := NewDatasource()
+func createDatasource(config Config, token string) error {
+	ds := NewDatasource(config)
 	const name = "MySQLTEST"
 
 	if ds == nil {
@@ -92,7 +92,7 @@ func TestInitGrafanaAPIToken(t *testing.T) {
 		assert.Nil(cleanerFn())
 	}()
 
-	InitGrafanaConfig(grafanaURL, "admin", "admin")
-	grafanaManager := NewGrafanaManagement()
+	config := NewConfig(grafanaURL, "admin", "admin")
+	grafanaManager := NewGrafanaManagement(config)
 	assert.Nil(grafanaManager.InitGrafanaAPIToken())
 }

--- a/src/api-server/http/http.go
+++ b/src/api-server/http/http.go
@@ -61,9 +61,9 @@ type Config struct {
 func StartHTTPService(cfg Config, pgClient *pg.Client) error {
 	log.Infof("Starting API Server's http service ...")
 
-	grafana.InitGrafanaConfig(cfg.GrafanaURL, cfg.GrafanaUserName, cfg.GrafanaUserPass)
+	config := grafana.NewConfig(cfg.GrafanaURL, cfg.GrafanaUserName, cfg.GrafanaUserPass)
 
-	grafanaManager := grafana.NewGrafanaManagement()
+	grafanaManager := grafana.NewGrafanaManagement(config)
 	err := grafanaManager.InitGrafanaAPIToken()
 	if err != nil {
 		msg := fmt.Sprintf("Failed to initialize Grafana API token, error: %v", err)
@@ -75,6 +75,7 @@ func StartHTTPService(cfg Config, pgClient *pg.Client) error {
 	}
 
 	mgr := ModuleManager{
+		grafanaConfig:  config,
 		DatasourceUID:  cfg.DatasourceUID,
 		GrafanaClient:  grafanaManager,
 		Module:         cfg.Module,

--- a/src/api-server/http/module_manager.go
+++ b/src/api-server/http/module_manager.go
@@ -90,10 +90,11 @@ func (mgr *ModuleManager) createModule(body CreateModuleReq) CreateModuleResp {
 
 	ebpfProbes, err := json.Marshal(body.Ebpf.Probes)
 	if err != nil {
-		log.Errorf("while creating module, failed to marshal ebpf probespecs, error: %v", err)
+		msg := fmt.Sprintf("while creating module, failed to marshal ebpf probespecs, error: %v", err)
+		log.Errorf(msg)
 		return CreateModuleResp{HTTPResp{
 			Code:    500,
-			Message: "request error: " + err.Error(),
+			Message: msg,
 		}}
 	}
 
@@ -106,9 +107,11 @@ func (mgr *ModuleManager) createModule(body CreateModuleReq) CreateModuleResp {
 
 	schemaAttr, err := json.Marshal(body.Wasm.OutputSchema.Fields)
 	if err != nil {
+		msg := fmt.Sprintf("while creating module, failed to marshal WASM output schema, error: %v", err)
+		log.Errorf(msg)
 		return CreateModuleResp{HTTPResp{
 			Code:    500,
-			Message: "request error: " + err.Error(),
+			Message: msg,
 		}}
 	}
 
@@ -132,18 +135,15 @@ func (mgr *ModuleManager) createModule(body CreateModuleReq) CreateModuleResp {
 	mod.SchemaName = fmt.Sprintf("%s_%s", "tricorder_module", mod.ID)
 
 	err = mgr.gLock.ExecWithLock(func() error {
-		err = mgr.Module.SaveModule(mod)
-		if err != nil {
-			log.Errorf("save module error: %v", err)
-			return errors.New("Save module error: " + err.Error())
-		}
-		return nil
+		return mgr.Module.SaveModule(mod)
 	})
 
 	if err != nil {
+		msg := fmt.Sprintf("while creating module, failed to save module ORM object, error: %v", err)
+		log.Errorf(msg)
 		return CreateModuleResp{HTTPResp{
 			Code:    500,
-			Message: err.Error(),
+			Message: msg,
 		}}
 	}
 

--- a/src/api-server/http/module_manager.go
+++ b/src/api-server/http/module_manager.go
@@ -39,6 +39,7 @@ import (
 
 // ModuleManager provides APIs to manage eBPF+WASM module received from the management Web UI.
 type ModuleManager struct {
+	grafanaConfig  grafana.Config
 	DatasourceUID  string
 	Module         dao.ModuleDao
 	NodeAgent      dao.NodeAgentDao
@@ -355,7 +356,7 @@ func (mgr *ModuleManager) deployModule(id string) DeployModuleResp {
 		return DeployModuleResp{
 			HTTPResp{
 				Code:    500,
-				Message: "create dashboard error",
+				Message: fmt.Sprintf("failed to create dashboard, error: %v", err),
 			},
 			uid,
 		}
@@ -517,7 +518,7 @@ func (mgr *ModuleManager) createGrafanaDashboard(moduleID string) (string, error
 		return "", err
 	}
 
-	ds := grafana.NewDashboard()
+	ds := grafana.NewDashboard(mgr.grafanaConfig)
 	result, err := ds.CreateDashboard(grafanaAPIKey, getModuleDataTableName(moduleID), mgr.DatasourceUID)
 	if err != nil {
 		log.Println("Create dashboard", err)


### PR DESCRIPTION
# Describe your changes
Previous code uses global variable to store configurations for Grafana component.
This PR moved them into a type Config, and passes Config object to Grafana component code.
Most of the changes are updating caller code, and fixing tests.

## Issue
- [ ] Check this box if this PR fixes an issue, and then paste the link below
- [x] No associated issue

## Test:
- [x] Check this box if this PR has tests
- [ ] No test needed
