### PR TITLE
Allow .c file as input for bcc file

### DIFF
--- a/src/cli/cmd/module/create.go
+++ b/src/cli/cmd/module/create.go
@@ -53,8 +53,9 @@ var createCmd = &cobra.Command{
 			}
 		}
 		if bccFilePath != "" {
-			if file.GetFileType(bccFilePath) != file.BCC {
-				log.Fatalf("Failed to read --bcc-file-path='%s', error: suffix is not .bcc", bccFilePath)
+			fileType := file.GetFileType(bccFilePath)
+			if fileType != file.C {
+				log.Fatalf("Failed to read --bcc-file-path='%s', error: suffix is not '%s'", bccFilePath, file.C)
 			}
 		}
 	},


### PR DESCRIPTION
# Describe your changes

We changed bcc file suffix to `.bcc.c`; so CLI's file type check is updated to match the new rule.

## Issue
- [ ] Check this box if this PR fixes an issue, and then paste the link below
- [x] No associated issue

## Test:
- [x] Check this box if this PR has tests
- [ ] No test needed
